### PR TITLE
Update freeu.py

### DIFF
--- a/scripts/freeu.py
+++ b/scripts/freeu.py
@@ -43,7 +43,7 @@ class FreeUScript(scripts.Script):
                     type="value",
                     elem_id=self.elem_id("preset_name"),
                     allow_custom_value=True,
-                    tooltip="Apply button loads settings\nWrite custom name to enable save\nDelete automatically will save to file"
+                    tooltip="Apply button loads settings\nWrite custom name to enable save\nDelete automatically will save to file",
                 )
 
                 is_custom_preset = preset_name.value not in global_state.default_presets

--- a/scripts/freeu.py
+++ b/scripts/freeu.py
@@ -43,8 +43,7 @@ class FreeUScript(scripts.Script):
                     type="value",
                     elem_id=self.elem_id("preset_name"),
                     allow_custom_value=True,
-                    tooltip="Apply button loads settings\nWrite custom name to enable save\nDelete automatically will save to file",
-                    size="sm",
+                    tooltip="Apply button loads settings\nWrite custom name to enable save\nDelete automatically will save to file"
                 )
 
                 is_custom_preset = preset_name.value not in global_state.default_presets


### PR DESCRIPTION
Hello! It's a mini-fix for that:
```
D:\AI\NS\modules\gradio_extensons.py:25: GradioUnusedKwargWarning: You have unused kwarg parameters in Dropdown, please remove them: {'size': 'sm'}
  res = original_IOComponent_init(self, *args, **kwargs)
```

The error (kwargs / warning) is displayed when the setting (in Stable Diffusion) is enabled: "Show gradio deprecation warnings in console."
I understand that the request is only one-line - but at least watch it.